### PR TITLE
Upgrading Go, adding a build dep, updating README & tfvars

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ $ sed -i "s/FIXME_USER/$USER/" terraform.tfvars
 ```
 
 Check terraform.tfvars and change any values you would like to change:
-- You may need to modify the network ID to one which is not in use.  
-- We assume your home directory is at `/Users/$USER` for locating your keyfiles, you will need to update the `public_key_path` (and `private_key_path`, if present) if that isn't the case.
-- Note that the values given in examples.tfvars are NOT completely AWS free tier eligible, as they include t2.small and t2.medium instances. We do not recommend using t2.micro instances, as they were unable to compile solidity during testing.
+- **SSH Location:** Our default example file is built for OS X, which puts your home directory and its `.ssh` folder (aka `~/.ssh`) at `/Users/$USER/.ssh`.  If your SSH keyfile is not located within that directory, you will need to update the `public_key_path`.
+- **Network ID:** We have a default network value.  If there is already a network running with this ID on your AWS account, you need to change the network ID or there will be a conflict.  
+- **Not Free:** The values given in `example.tfvars` are NOT completely AWS free tier eligible, as they include t2.small and t2.medium instances. We do not recommend using t2.micro instances, as they were unable to compile solidity during testing.
 
 If it is your first time using this package, you will need to run `terraform init` before applying the configuration.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 Table of Contents
 =================
 
@@ -120,7 +121,7 @@ $ cp example.tfvars terraform.tfvars
 Fill in your username as the `cert_owner`:
 
 ```sh
-$ sed -i '' "s/FIXME_USER/$USER/" terraform.tfvars
+$ sed -i "s/FIXME_USER/$USER/" terraform.tfvars
 ```
 
 Check terraform.tfvars and change any values you would like to change. Note that the values given in examples.tfvars is NOT completely AWS free tier eligible, as they include t2.small and t2.medium instances. We do not recommend using t2.micro instances, as they were unable to compile solidity during testing.
@@ -163,6 +164,8 @@ $ /opt/vault/bin/setup-vault.sh $ROOT_TOKEN
 ```
 
 If any of these commands fail, wait a short time and try again. If waiting doesn't fix the issue, you may need to destroy and recreate the infrastructure.
+
+Note: The `setup-vault.sh` command will produce one error for each supported region that does not have a bootnode.  Those are expected and can be ignored.
 
 ### Unseal additional vault servers
 

--- a/README.md
+++ b/README.md
@@ -118,13 +118,16 @@ $ cd terraform
 $ cp example.tfvars terraform.tfvars
 ```
 
-Fill in your username as the `cert_owner`:
+Fill in your username as the `cert_owner` via:
 
 ```sh
 $ sed -i "s/FIXME_USER/$USER/" terraform.tfvars
 ```
 
-Check terraform.tfvars and change any values you would like to change. Note that the values given in examples.tfvars is NOT completely AWS free tier eligible, as they include t2.small and t2.medium instances. We do not recommend using t2.micro instances, as they were unable to compile solidity during testing.
+Check terraform.tfvars and change any values you would like to change:
+- You may need to modify the network ID to one which is not in use.  
+- We assume your home directory is at `/Users/$USER` for locating your keyfiles, you will need to update the `public_key_path` (and `private_key_path`, if present) if that isn't the case.
+- Note that the values given in examples.tfvars are NOT completely AWS free tier eligible, as they include t2.small and t2.medium instances. We do not recommend using t2.micro instances, as they were unable to compile solidity during testing.
 
 If it is your first time using this package, you will need to run `terraform init` before applying the configuration.
 

--- a/packer/provisioning-scripts/build-deps.sh
+++ b/packer/provisioning-scripts/build-deps.sh
@@ -2,7 +2,7 @@
 set -eu -o pipefail
 
 sudo apt-get update
-sudo apt-get install -y build-essential unzip cmake libdb-dev libleveldb-dev libboost-all-dev libsodium-dev zlib1g-dev libtinfo-dev sysvbanner wrk git npm automake autotools-dev fuse g++ libcurl4-gnutls-dev libfuse-dev libssl-dev libxml2-dev make pkg-config python-pip ntp
+sudo apt-get install -y build-essential unzip cmake libdb-dev libleveldb-dev libboost-all-dev libsodium-dev zlib1g-dev libtinfo-dev sysvbanner wrk git npm automake autotools-dev fuse g++ libcurl4-gnutls-dev libfuse-dev libssl-dev libxml2-dev make pkg-config python-pip ntp libsasl2-dev
 sudo pip install boto3 ethjsonrpc
 # Add repository for current version of node
 curl -sL https://deb.nodesource.com/setup_8.x | sudo -E bash -

--- a/packer/provisioning-scripts/golang.sh
+++ b/packer/provisioning-scripts/golang.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eu -o pipefail
 
-GOREL=go1.7.3.linux-amd64.tar.gz
+GOREL=go1.10.3.linux-amd64.tar.gz
 BASH_PROFILE=/home/ubuntu/.bash_profile
 
 wget -q https://storage.googleapis.com/golang/$GOREL

--- a/terraform/example.tfvars
+++ b/terraform/example.tfvars
@@ -1,4 +1,4 @@
-public_key_path                = "~/.ssh/quorum.pub"
+public_key_path                = "/Users/FIXME_USER/.ssh/quorum.pub"
 primary_region                 = "us-east-1"
 cert_owner                     = "FIXME_USER"
 key_name                       = "quorum-cluster"


### PR DESCRIPTION
## Motivation

We currently pass the password directly to the `quorum` instance, but this means that the shell touches the password and it gets written to disk.  If we instead tell `quorum` how to retrieve the password from Vault, then the password can always stay in memory.

## Key Modifications

Only minimal changes are required here.  [`init-quorum`](packer/instance-scripts/init-quorum.sh) needs the `generate_quorum_supervisor_config` function to add `vaultaddr` and `vaultpasswordpath` arguments to the `geth` command it writes.  

- `vaultaddr`: Already encoded in `init-quorum`'s environment at `VAULT_ADDR` by its sister script, [`generate-run-init-quorum`](packer/instance-scripts/generate-run-init-quorum).
- `vaultpasswordpath`: A string shaped like `/quorum/passwords/$AWS_REGION/$CLUSTER_INDEX`, corresponding to the Vault KV store where the password is kept.  We want the value behind key `geth-pw`.  Those variables come from files:
  - `local AWS_REGION=$(cat /opts/quorum/info/aws-region.txt)`
  - `local CLUSTER_INDEX=$(cat /opts/quorum/info/overall-index.txt)`

Adding the AWS and Vault APIs to our `quorum` also required that I add a C dependency (`libsasl2-dev`) and upgrade Go to `go1.10.3`.

Note: This pull request assumes that my pull request to `quorum` has also been merged into `v1.2.1-modified`, as I removed my modifications to `packer/provisioning-scripts/quorum.sh`.