### PR TITLE
Bootnode replacement: elastic IPs + autoscaling groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,3 @@
-# Replacing Bootnodes
-This branch will resolve [Issue #5: Bootnodes should be replaceable](https://github.com/Eximchain/terraform-aws-quorum-cluster/issues/5).  I am refactoring the bootnodes' terraform configuration so that we can support long-term static IP addresses even as we replace the underlying machines.  Right now, bootnodes are regular AWS instances which will eventually fall over -- their replacements will have different IPs.  This is incompatible with the [`enode` address spec](https://github.com/ethereum/wiki/wiki/enode-url-format), which requires a static IP.
-
-The solution strategy is to simulate a static IP by giving each bootnode an elastic IP and an autoscaling group.  The elastic IP will be stable for the long-term and can be reassociated with replacement nodes, while the autoscaling group will ensure that nodes will get automagically replaced when they go down.  [This commit](https://github.com/Eximchain/terraform-aws-quorum-cluster/commit/839b4c70c18164efa2c32af0e8b9026f55a26ff2) from Louis shows how he refactored other nodes to use autoscaling groups, that's the baseline pattern I'll be using for my implementation.
-
-*- John O'Sullivan*
-
 Table of Contents
 =================
 

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ $ /opt/vault/bin/setup-vault.sh $ROOT_TOKEN
 
 If any of these commands fail, wait a short time and try again. If waiting doesn't fix the issue, you may need to destroy and recreate the infrastructure.
 
-Note: The `setup-vault.sh` command will produce one error for each supported region that does not have a bootnode.  Those are expected and can be ignored.
+> Note: The `setup-vault.sh` command will produce one error for each supported region that does not have a bootnode.  Those are expected and can be ignored.
 
 ### Unseal additional vault servers
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Load-Balanced Auto-Scaling Group Bootnodes
+# Replacing Bootnodes
 This branch will resolve [Issue #5: Bootnodes should be replaceable](https://github.com/Eximchain/terraform-aws-quorum-cluster/issues/5).  I am refactoring the bootnodes' terraform configuration so that we can support long-term static IP addresses even as we replace the underlying machines.  Right now, bootnodes are regular AWS instances which will eventually fall over -- their replacements will have different IPs.  This is incompatible with the [`enode` address spec](https://github.com/ethereum/wiki/wiki/enode-url-format), which requires a static IP.
 
-The solution strategy is to simulate a static IP by giving each bootnode a load balancer and an autoscaling group.  The load balancer provides a static IP which we can use long-term, while the autoscaling group will ensure that nodes will get automagically replaced when they go down.  [This commit](https://github.com/Eximchain/terraform-aws-quorum-cluster/commit/839b4c70c18164efa2c32af0e8b9026f55a26ff2) from Louis shows how he refactored other nodes to use autoscaling groups, that's the baseline pattern I'll be using for my implementation.
+The solution strategy is to simulate a static IP by giving each bootnode an elastic IP and an autoscaling group.  The elastic IP will be stable for the long-term and can be reassociated with replacement nodes, while the autoscaling group will ensure that nodes will get automagically replaced when they go down.  [This commit](https://github.com/Eximchain/terraform-aws-quorum-cluster/commit/839b4c70c18164efa2c32af0e8b9026f55a26ff2) from Louis shows how he refactored other nodes to use autoscaling groups, that's the baseline pattern I'll be using for my implementation.
 
 *- John O'Sullivan*
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# Load-Balanced Auto-Scaling Group Bootnodes
+This branch will resolve [Issue #5: Bootnodes should be replaceable](https://github.com/Eximchain/terraform-aws-quorum-cluster/issues/5).  I am refactoring the bootnodes' terraform configuration so that we can support long-term static IP addresses even as we replace the underlying machines.  Right now, bootnodes are regular AWS instances which will eventually fall over -- their replacements will have different IPs.  This is incompatible with the [`enode` address spec](https://github.com/ethereum/wiki/wiki/enode-url-format), which requires a static IP.
+
+The solution strategy is to simulate a static IP by giving each bootnode a load balancer and an autoscaling group.  The load balancer provides a static IP which we can use long-term, while the autoscaling group will ensure that nodes will get automagically replaced when they go down.  [This commit](https://github.com/Eximchain/terraform-aws-quorum-cluster/commit/839b4c70c18164efa2c32af0e8b9026f55a26ff2) from Louis shows how he refactored other nodes to use autoscaling groups, that's the baseline pattern I'll be using for my implementation.
+
+*- John O'Sullivan*
 
 Table of Contents
 =================

--- a/packer/instance-scripts/init-bootnode.sh
+++ b/packer/instance-scripts/init-bootnode.sh
@@ -88,12 +88,11 @@ wait_for_terraform_provisioners
 # Get metadata for this instance
 INDEX=$(cat /opt/quorum/info/index.txt)
 AWS_REGION=$(cat /opt/quorum/info/aws-region.txt)
-LB_DNS=$(cat /opt/quorum/info/lb_dns.txt)
+HOSTNAME=$(cat /opt/quorum/info/lb_dns.txt)
+echo "dig +short (next line):"
+PUBLIC_IP=$(dig +short $HOSTNAME)
+echo $PUBLIC_IP
 BOOT_PORT=30301
-
-# Fetching HOSTNAME
-# Old HOSTNAME=$(wait_for_successful_command 'curl http://169.254.169.254/latest/meta-data/public-hostname')
-# New: hostname should be contained in the LB_DNS
 
 # Fetching PUBLIC_IP
 # Old PUBLIC_IP=$(wait_for_successful_command 'curl http://169.254.169.254/latest/meta-data/public-ipv4')

--- a/packer/instance-scripts/init-bootnode.sh
+++ b/packer/instance-scripts/init-bootnode.sh
@@ -75,8 +75,8 @@ wait_for_successful_command 'vault auth -method=aws'
 # Get metadata for this instance
 INDEX=$(cat /opt/quorum/info/index.txt)
 AWS_REGION=$(cat /opt/quorum/info/aws-region.txt)
-PUBLIC_IP=$(cat /opt/quorum/info/public_ip.txt)
-EIP_ID=$(cat /opt/quorum/info/eip_id.txt)
+PUBLIC_IP=$(cat /opt/quorum/info/public-ip.txt)
+EIP_ID=$(cat /opt/quorum/info/eip-id.txt)
 INSTANCE_ID=$(wait_for_successful_command 'curl -s http://169.254.169.254/latest/meta-data/instance-id')
 HOSTNAME=$(wait_for_successful_command 'curl http://169.254.169.254/latest/meta-data/public-hostname')
 BOOT_PORT=30301

--- a/packer/instance-scripts/init-bootnode.sh
+++ b/packer/instance-scripts/init-bootnode.sh
@@ -72,6 +72,10 @@ function wait_for_terraform_provisioners {
     done
 }
 
+function resolve_public_dns_to_ip {
+
+}
+
 # Wait for operator to initialize and unseal vault
 wait_for_successful_command 'vault init -check'
 wait_for_successful_command 'vault status'
@@ -84,9 +88,17 @@ wait_for_terraform_provisioners
 # Get metadata for this instance
 INDEX=$(cat /opt/quorum/info/index.txt)
 AWS_REGION=$(cat /opt/quorum/info/aws-region.txt)
-PUBLIC_IP=$(wait_for_successful_command 'curl http://169.254.169.254/latest/meta-data/public-ipv4')
-HOSTNAME=$(wait_for_successful_command 'curl http://169.254.169.254/latest/meta-data/public-hostname')
+LB_DNS=$(cat /opt/quorum/info/lb_dns.txt)
 BOOT_PORT=30301
+
+# Fetching HOSTNAME
+# Old HOSTNAME=$(wait_for_successful_command 'curl http://169.254.169.254/latest/meta-data/public-hostname')
+# New: hostname should be contained in the LB_DNS
+
+# Fetching PUBLIC_IP
+# Old PUBLIC_IP=$(wait_for_successful_command 'curl http://169.254.169.254/latest/meta-data/public-ipv4')
+# Naive: PUBLIC_IP=$(dig +short $LB_DNS)
+# Issue: Searching from within same VPC might return private IP instead of public
 
 # Generate bootnode key and construct bootnode address
 BOOT_KEY_FILE=/opt/quorum/private/boot.key

--- a/packer/instance-scripts/init-bootnode.sh
+++ b/packer/instance-scripts/init-bootnode.sh
@@ -71,7 +71,6 @@ wait_for_successful_command 'vault init -check'
 wait_for_successful_command 'vault status'
 
 # Wait for vault to be fully configured by the root user
-echo ">> Before Vault auth"
 wait_for_successful_command 'vault auth -method=aws'
 
 # Get metadata for this instance
@@ -134,7 +133,7 @@ CONSTELLATION_PRIV_KEY=$(cat /opt/quorum/constellation/private/constellation.key
 
 # Write bootnode address to vault
 wait_for_successful_command "vault write quorum/bootnodes/keys/$AWS_REGION/$INDEX bootnode_key=\"$BOOT_KEY\" constellation_priv_key=\"$CONSTELLATION_PRIV_KEY\""
-wait_for_successful_command "vault write quorum/bootnodes/addresses/$AWS_REGION/$INDEX enode=$BOOT_ADDR pub_key=$BOOT_PUB hostname=$HOSTNAME constellation_pub_key=$CONSTELLATION_PUB_KEY"
+wait_for_successful_command "vault write quorum/bootnodes/addresses/$AWS_REGION/$INDEX enode=$BOOT_ADDR pub_key=$BOOT_PUB hostname=$PUBLIC_IP constellation_pub_key=$CONSTELLATION_PUB_KEY"
 # Wait for all bootnodes to write their address to vault
 wait_for_all_bootnodes
 

--- a/packer/instance-scripts/init-bootnode.sh
+++ b/packer/instance-scripts/init-bootnode.sh
@@ -64,7 +64,6 @@ function run_threatstack_agent_if_configured {
   fi
 }
 
-echo ">> Before Vault init/status check"
 
 # Wait for operator to initialize and unseal vault
 wait_for_successful_command 'vault init -check'

--- a/packer/instance-scripts/init-bootnode.sh
+++ b/packer/instance-scripts/init-bootnode.sh
@@ -72,11 +72,14 @@ function wait_for_terraform_provisioners {
     done
 }
 
+echo ">> Before Vault init/status check"
+
 # Wait for operator to initialize and unseal vault
 wait_for_successful_command 'vault init -check'
 wait_for_successful_command 'vault status'
 
 # Wait for vault to be fully configured by the root user
+echo ">> Before Vault auth"
 wait_for_successful_command 'vault auth -method=aws'
 
 wait_for_terraform_provisioners
@@ -86,12 +89,15 @@ INDEX=$(cat /opt/quorum/info/index.txt)
 AWS_REGION=$(cat /opt/quorum/info/aws-region.txt)
 PUBLIC_IP=$(cat /opt/quorum/info/public_ip.txt)
 EIP_ID=$(cat /opt/quorum/info/eip_id.txt)
+echo ">> Before AWS magic URL calls"
 INSTANCE_ID=$(wait_for_successful_command 'curl -s http://169.254.169.254/latest/meta-data/instance-id')
 HOSTNAME=$(wait_for_successful_command 'curl http://169.254.169.254/latest/meta-data/public-hostname')
 BOOT_PORT=30301
 
 # Associate the EIP with this instance
-aws ec2 associate-address --instance-id $INSTANCE_ID --allocation-id $EIP_ID --allow-reassociation
+echo ">> Before AWS EC2 CLI call"
+wait_for_successful_command 'aws ec2 associate-address --instance-id $INSTANCE_ID --allocation-id $EIP_ID --allow-reassociation'
+echo ">> After AWS EC2 CLI call"
 
 # Generate bootnode key and construct bootnode address
 BOOT_KEY_FILE=/opt/quorum/private/boot.key
@@ -142,7 +148,7 @@ CONSTELLATION_PRIV_KEY=$(cat /opt/quorum/constellation/private/constellation.key
 # Write bootnode address to vault
 wait_for_successful_command "vault write quorum/bootnodes/keys/$AWS_REGION/$INDEX bootnode_key=\"$BOOT_KEY\" constellation_priv_key=\"$CONSTELLATION_PRIV_KEY\""
 wait_for_successful_command "vault write quorum/bootnodes/addresses/$AWS_REGION/$INDEX enode=$BOOT_ADDR pub_key=$BOOT_PUB hostname=$HOSTNAME constellation_pub_key=$CONSTELLATION_PUB_KEY"
-
+echo "All Vault commands complete"
 # Wait for all bootnodes to write their address to vault
 wait_for_all_bootnodes
 

--- a/packer/instance-scripts/init-bootnode.sh
+++ b/packer/instance-scripts/init-bootnode.sh
@@ -79,22 +79,22 @@ PUBLIC_IP=$(cat /opt/quorum/info/public-ip.txt)
 USING_EIP=$(cat /opt/quorum/info/using-eip.txt)
 EIP_ID=$(cat /opt/quorum/info/eip-id.txt)
 INSTANCE_ID=$(wait_for_successful_command 'curl -s http://169.254.169.254/latest/meta-data/instance-id')
-HOSTNAME=$(wait_for_successful_command 'curl http://169.254.169.254/latest/meta-data/public-hostname')
 BOOT_PORT=30301
 
 # Associate the EIP with this instance
-echo ">> Value of USING_EIP follows on next line:"
-echo ">> $USING_EIP"
-echo ">> (value printed)"
 if [ "$USING_EIP" == "1" ]
 then
-    echo ">> Found USING_EIP == 1, running aws ec2 associate-address"
     wait_for_successful_command "aws ec2 associate-address --instance-id $INSTANCE_ID --allocation-id $EIP_ID --region $AWS_REGION --allow-reassociation"
-else
-    echo ">> Found USING_EIP != 0, reading PUBLIC_IP from AWS"
-    echo ">> For good measure, value of USING_EIP was : $USING_EIP"
+elif [ "$USING_EIP"  == "0" ]
+then
     PUBLIC_IP=$(wait_for_successful_command 'curl -s http://169.254.169.254/latest/meta-data/public-ipv4')
+else 
+    echo ">> FATAL ERROR: USING_EIP needs to be boolean with value 0 or 1, instead has value $USING_EIP.  Erroring out."
+    exit 1
 fi
+
+# Fetch hostname after EIP association, as that changes hostname value.
+HOSTNAME=$(wait_for_successful_command 'curl http://169.254.169.254/latest/meta-data/public-hostname')
 
 # Generate bootnode key and construct bootnode address
 BOOT_KEY_FILE=/opt/quorum/private/boot.key

--- a/packer/instance-scripts/init-bootnode.sh
+++ b/packer/instance-scripts/init-bootnode.sh
@@ -72,10 +72,6 @@ function wait_for_terraform_provisioners {
     done
 }
 
-function resolve_public_dns_to_ip {
-
-}
-
 # Wait for operator to initialize and unseal vault
 wait_for_successful_command 'vault init -check'
 wait_for_successful_command 'vault status'
@@ -88,16 +84,14 @@ wait_for_terraform_provisioners
 # Get metadata for this instance
 INDEX=$(cat /opt/quorum/info/index.txt)
 AWS_REGION=$(cat /opt/quorum/info/aws-region.txt)
-HOSTNAME=$(cat /opt/quorum/info/lb_dns.txt)
-echo "dig +short (next line):"
-PUBLIC_IP=$(dig +short $HOSTNAME)
-echo $PUBLIC_IP
+PUBLIC_IP=$(cat /opt/quorum/info/public_ip.txt)
+EIP_ID=$(cat /opt/quorum/info/eip_id.txt)
+INSTANCE_ID=$(wait_for_successful_command 'curl -s http://169.254.169.254/latest/meta-data/instance-id')
+HOSTNAME=$(wait_for_successful_command 'curl http://169.254.169.254/latest/meta-data/public-hostname')
 BOOT_PORT=30301
 
-# Fetching PUBLIC_IP
-# Old PUBLIC_IP=$(wait_for_successful_command 'curl http://169.254.169.254/latest/meta-data/public-ipv4')
-# Naive: PUBLIC_IP=$(dig +short $LB_DNS)
-# Issue: Searching from within same VPC might return private IP instead of public
+# Associate the EIP with this instance
+aws ec2 associate-address --instance-id $INSTANCE_ID --allocation-id $EIP_ID --allow-reassociation
 
 # Generate bootnode key and construct bootnode address
 BOOT_KEY_FILE=/opt/quorum/private/boot.key

--- a/terraform/example.tfvars
+++ b/terraform/example.tfvars
@@ -11,6 +11,7 @@ use_dedicated_validators       = false
 use_dedicated_observers        = false
 use_dedicated_vault_servers    = false
 use_dedicated_consul_servers   = false
+use_elastic_bootnode_ips       = false
 vault_cluster_size             = 1
 vault_instance_type            = "t2.small"
 consul_cluster_size            = 1

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -26,6 +26,7 @@ module "quorum_cluster" {
   use_dedicated_observers        = "${var.use_dedicated_observers}"
   use_dedicated_vault_servers    = "${var.use_dedicated_vault_servers}"
   use_dedicated_consul_servers   = "${var.use_dedicated_consul_servers}"
+  use_elastic_bootnode_ips       = "${var.use_elastic_bootnode_ips}"
   node_volume_size               = "${var.node_volume_size}"
   threatstack_deploy_key         = "${var.threatstack_deploy_key}"
   vault_enterprise_license_key   = "${var.vault_enterprise_license_key}"

--- a/terraform/modules/quorum-cluster-region/bootnodes.tf
+++ b/terraform/modules/quorum-cluster-region/bootnodes.tf
@@ -106,8 +106,12 @@ data "template_file" "user_data_bootnode" {
     primary_region = "${var.primary_region}"
     network_id = "${var.network_id}"
     use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
-    public_ip = "${var.use_elastic_bootnode_ips ? element(aws_eip.bootnodes.*.public_ip, count.index) : "nil"}"
-    eip_id = "${var.use_elastic_bootnode_ips ? element(aws_eip.bootnodes.*.id, count.index) : "nil"}"
+
+    # concat() is called to ensure there is always at least one element in the list,
+    # as element() cannot be called on empty list.  Solution is hacky, but also the
+    # only one available per Terraform issue: https://github.com/hashicorp/terraform/issues/11210
+    public_ip = "${var.use_elastic_bootnode_ips ? element(concat(aws_eip.bootnodes.*.public_ip, list("")), count.index) : "nil"}"
+    eip_id = "${var.use_elastic_bootnode_ips ? element(concat(aws_eip.bootnodes.*.id, list("")), count.index) : "nil"}"
 
     vault_dns  = "${var.vault_dns}"
     vault_port = "${var.vault_port}"

--- a/terraform/modules/quorum-cluster-region/bootnodes.tf
+++ b/terraform/modules/quorum-cluster-region/bootnodes.tf
@@ -72,11 +72,11 @@ resource "aws_autoscaling_group" "bootnodes" {
 }
 
 resource "aws_eip" "bootnodes" {
-  count = "${lookup(var.bootnode_counts, var.aws_region, 0)}"
+  count = "${var.use_elastic_bootnode_ips ? lookup(var.bootnode_counts, var.aws_region, 0) : 0}"
   vpc = true
 }
 
-data "aws_instance" "bootnode" {
+data "aws_instance" "bootnodes" {
   count = "${aws_autoscaling_group.bootnodes.count}"
 
   filter {
@@ -105,8 +105,9 @@ data "template_file" "user_data_bootnode" {
     aws_region = "${var.aws_region}"
     primary_region = "${var.primary_region}"
     network_id = "${var.network_id}"
-    public_ip = "${element(aws_eip.bootnodes.*.public_ip, count.index)}"
-    eip_id = "${element(aws_eip.bootnodes.*.id, count.index)}"
+    use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
+    public_ip = "${var.use_elastic_bootnode_ips ? element(aws_eip.bootnodes.*.public_ip, count.index) : false}"
+    eip_id = "${var.use_elastic_bootnode_ips ? element(aws_eip.bootnodes.*.id, count.index) : false}"
 
     vault_dns  = "${var.vault_dns}"
     vault_port = "${var.vault_port}"

--- a/terraform/modules/quorum-cluster-region/bootnodes.tf
+++ b/terraform/modules/quorum-cluster-region/bootnodes.tf
@@ -37,9 +37,11 @@ resource "aws_subnet" "bootnodes" {
 resource "aws_launch_configuration" "bootnodes" {
   count = "${lookup(var.bootnode_counts, var.aws_region, 0)}"
 
+  name_prefix = "quorum-bootnode-net-${var.network_id}-node-${count.index}"
+
   image_id   = "${var.bootnode_ami == "" ? data.aws_ami.bootnode.id : var.bootnode_ami}"
   instance_type = "${var.bootnode_instance_type}"
-  user_data = "${data.template_file.user_data_bootnode.rendered}"
+  user_data = "${element(data.template_file.user_data_bootnode.*.rendered, count.index)}"
 
   key_name = "${aws_key_pair.auth.id}"
 

--- a/terraform/modules/quorum-cluster-region/bootnodes.tf
+++ b/terraform/modules/quorum-cluster-region/bootnodes.tf
@@ -37,7 +37,7 @@ resource "aws_subnet" "bootnodes" {
 resource "aws_launch_configuration" "bootnodes" {
   count = "${lookup(var.bootnode_counts, var.aws_region, 0)}"
 
-  name_prefix = "quorum-bootnode-net-${var.network_id}-node-${count.index}"
+  name_prefix = "quorum-bootnode-net-${var.network_id}-node-${count.index}-"
 
   image_id   = "${var.bootnode_ami == "" ? data.aws_ami.bootnode.id : var.bootnode_ami}"
   instance_type = "${var.bootnode_instance_type}"
@@ -106,8 +106,8 @@ data "template_file" "user_data_bootnode" {
     primary_region = "${var.primary_region}"
     network_id = "${var.network_id}"
     use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
-    public_ip = "${var.use_elastic_bootnode_ips ? element(aws_eip.bootnodes.*.public_ip, count.index) : false}"
-    eip_id = "${var.use_elastic_bootnode_ips ? element(aws_eip.bootnodes.*.id, count.index) : false}"
+    public_ip = "${var.use_elastic_bootnode_ips ? element(aws_eip.bootnodes.*.public_ip, count.index) : "nil"}"
+    eip_id = "${var.use_elastic_bootnode_ips ? element(aws_eip.bootnodes.*.id, count.index) : "nil"}"
 
     vault_dns  = "${var.vault_dns}"
     vault_port = "${var.vault_port}"

--- a/terraform/modules/quorum-cluster-region/bootnodes.tf
+++ b/terraform/modules/quorum-cluster-region/bootnodes.tf
@@ -70,7 +70,7 @@ resource "aws_autoscaling_group" "bootnodes" {
 }
 
 resource "aws_eip" "bootnodes" {
-  count = "${aws_launch_configuration.bootnodes.count}"
+  count = "${lookup(var.bootnode_counts, var.aws_region, 0)}"
   vpc = true
 }
 

--- a/terraform/modules/quorum-cluster-region/bootnodes.tf
+++ b/terraform/modules/quorum-cluster-region/bootnodes.tf
@@ -111,18 +111,18 @@ data "template_file" "user_data_bootnode" {
     # as element() cannot be called on empty list.  Solution is hacky, but lazy
     # ternary evaluation will drop in Terraform 0.12: https://www.hashicorp.com/blog/terraform-0-1-2-preview
     # If you're reading this and it has already released, try dropping the concat hack.
-    public_ip                = "${var.use_elastic_bootnode_ips ? element(concat(aws_eip.bootnodes.*.public_ip, list("")), count.index) : "nil"}"
-    eip_id                   = "${var.use_elastic_bootnode_ips ? element(concat(aws_eip.bootnodes.*.id, list("")), count.index) : "nil"}"
+    public_ip = "${var.use_elastic_bootnode_ips ? element(concat(aws_eip.bootnodes.*.public_ip, list("")), count.index) : "nil"}"
+    eip_id    = "${var.use_elastic_bootnode_ips ? element(concat(aws_eip.bootnodes.*.id, list("")), count.index) : "nil"}"
 
-    vault_dns                = "${var.vault_dns}"
-    vault_port               = "${var.vault_port}"
+    vault_dns  = "${var.vault_dns}"
+    vault_port = "${var.vault_port}"
 
     consul_cluster_tag_key   = "${var.consul_cluster_tag_key}"
     consul_cluster_tag_value = "${var.consul_cluster_tag_value}"
 
-    vault_cert_bucket        = "${var.vault_cert_bucket_name}"
+    vault_cert_bucket = "${var.vault_cert_bucket_name}"
 
-    threatstack_deploy_key   = "${var.threatstack_deploy_key}"
+    threatstack_deploy_key = "${var.threatstack_deploy_key}"
   }
 }
 

--- a/terraform/modules/quorum-cluster-region/bootnodes.tf
+++ b/terraform/modules/quorum-cluster-region/bootnodes.tf
@@ -99,29 +99,30 @@ data "template_file" "user_data_bootnode" {
   template = "${file("${path.module}/user-data/user-data-bootnode.sh")}"
 
   vars {
-    constellation_s3_bucket = "${aws_s3_bucket.quorum_constellation.id}"
-    index = "${count.index}"
-    bootnode_count_json = "${data.template_file.bootnode_count_json.rendered}"
-    aws_region = "${var.aws_region}"
-    primary_region = "${var.primary_region}"
-    network_id = "${var.network_id}"
+    constellation_s3_bucket  = "${aws_s3_bucket.quorum_constellation.id}"
+    index                    = "${count.index}"
+    bootnode_count_json      = "${data.template_file.bootnode_count_json.rendered}"
+    aws_region               = "${var.aws_region}"
+    primary_region           = "${var.primary_region}"
+    network_id               = "${var.network_id}"
     use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
 
     # concat() is called to ensure there is always at least one element in the list,
-    # as element() cannot be called on empty list.  Solution is hacky, but also the
-    # only one available per Terraform issue: https://github.com/hashicorp/terraform/issues/11210
-    public_ip = "${var.use_elastic_bootnode_ips ? element(concat(aws_eip.bootnodes.*.public_ip, list("")), count.index) : "nil"}"
-    eip_id = "${var.use_elastic_bootnode_ips ? element(concat(aws_eip.bootnodes.*.id, list("")), count.index) : "nil"}"
+    # as element() cannot be called on empty list.  Solution is hacky, but lazy
+    # ternary evaluation will drop in Terraform 0.12: https://www.hashicorp.com/blog/terraform-0-1-2-preview
+    # If you're reading this and it has already released, try dropping the concat hack.
+    public_ip                = "${var.use_elastic_bootnode_ips ? element(concat(aws_eip.bootnodes.*.public_ip, list("")), count.index) : "nil"}"
+    eip_id                   = "${var.use_elastic_bootnode_ips ? element(concat(aws_eip.bootnodes.*.id, list("")), count.index) : "nil"}"
 
-    vault_dns  = "${var.vault_dns}"
-    vault_port = "${var.vault_port}"
+    vault_dns                = "${var.vault_dns}"
+    vault_port               = "${var.vault_port}"
 
     consul_cluster_tag_key   = "${var.consul_cluster_tag_key}"
     consul_cluster_tag_value = "${var.consul_cluster_tag_value}"
 
-    vault_cert_bucket = "${var.vault_cert_bucket_name}"
+    vault_cert_bucket        = "${var.vault_cert_bucket_name}"
 
-    threatstack_deploy_key = "${var.threatstack_deploy_key}"
+    threatstack_deploy_key   = "${var.threatstack_deploy_key}"
   }
 }
 

--- a/terraform/modules/quorum-cluster-region/bootnodes.tf
+++ b/terraform/modules/quorum-cluster-region/bootnodes.tf
@@ -35,7 +35,7 @@ resource "aws_subnet" "bootnodes" {
 # BOOTNODE LAUNCH CONFIGURATION
 # ---------------------------------------------------------------------------------------------------------------------
 resource "aws_launch_configuration" "bootnodes" {
-  count = "${data.template_file.user_data_bootnode.count}"
+  count = "${lookup(var.bootnode_counts, var.aws_region, 0)}"
 
   image_id   = "${var.bootnode_ami == "" ? data.aws_ami.bootnode.id : var.bootnode_ami}"
   instance_type = "${var.bootnode_instance_type}"
@@ -50,14 +50,14 @@ resource "aws_launch_configuration" "bootnodes" {
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
-# BOOTNODE ASG
+# BOOTNODE ASG & ELASTIC IPs
 # ---------------------------------------------------------------------------------------------------------------------
 resource "aws_autoscaling_group" "bootnodes" {
   count = "${aws_launch_configuration.bootnodes.count}"
 
   name = "bootnode-net-${var.network_id}-node-${count.index}"
 
-  launch_configuration = "${element(aws_launch_configuration.bootnode.*.name, count.index)}"
+  launch_configuration = "${element(aws_launch_configuration.bootnodes.*.name, count.index)}"
 
   min_size = 1
   max_size = 1
@@ -69,40 +69,20 @@ resource "aws_autoscaling_group" "bootnodes" {
   vpc_zone_identifier = ["${element(aws_subnet.bootnodes.*.id, count.index)}"]
 }
 
-# ---------------------------------------------------------------------------------------------------------------------
-# BOOTNODE LOAD BALANCER
-# ---------------------------------------------------------------------------------------------------------------------
-resource "aws_lb" "bootnodes" {
+resource "aws_eip" "bootnodes" {
   count = "${aws_launch_configuration.bootnodes.count}"
-
-  internal = false
-  load_balancer_type = "network"
-  subnets = ["${aws_subnet.bootnodes.*.id}"]
-
-  # Q?: Apparently load balancers can't be modified without deleting them(?)
-  # Examples set this to true even though default is false, not sure why
-  # enable_deletion_protection = true
+  vpc = true
 }
 
-resource "aws_lb_listener" "bootnode" {
-  count = "${aws_launch_configuration.bootnodes.count}"
-  load_balancer_arn = "${aws_lb.bootnodes.*.arn}"
-  protocol = "TCP"
-  port = "30301"
+data "aws_instance" "bootnode" {
+  count = "${aws_autoscaling_group.bootnodes.count}"
 
-  default_action {
-    target_group_arn = "${aws_lb_target_group.bootnodes.*.arn}"
-    type = "forward"
+  filter {
+    name = "tag:aws:autoscaling:groupName"
+    values = ["${element(aws_autoscaling_group.bootnodes.*.name, count.index)}"]
   }
-}
 
-# TODO: enodes need to be accessible via both TCP & UDP.
-# Where do I configure the UDP access here?
-
-resource "aws_lb_target_group" "bootnodes" {
-  count = "${aws_launch_configuration.bootnodes.count}"
-  arn = "${aws_autoscaling_group.bootnodes.*.arn}"
-  port = "30301"
+  depends_on = ["aws_autoscaling_group.bootnodes"]
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -112,8 +92,7 @@ resource "aws_lb_target_group" "bootnodes" {
 
 data "template_file" "user_data_bootnode" {
 
-  # Q?: This looks like it assumes only one bootnode per region, is that true?
-  count = "${signum(lookup(var.bootnode_counts, var.aws_region, 0))}"
+  count = "${lookup(var.bootnode_counts, var.aws_region, 0)}"
 
   template = "${file("${path.module}/user-data/user-data-bootnode.sh")}"
 
@@ -124,7 +103,8 @@ data "template_file" "user_data_bootnode" {
     aws_region = "${var.aws_region}"
     primary_region = "${var.primary_region}"
     network_id = "${var.network_id}"
-    lb_dns = "${aws_lb.bootnodes.*.dns_name}"
+    public_ip = "${element(aws_eip.bootnodes.*.public_ip, count.index)}"
+    eip_id = "${element(aws_eip.bootnodes.*.id, count.index)}"
 
     vault_dns  = "${var.vault_dns}"
     vault_port = "${var.vault_port}"

--- a/terraform/modules/quorum-cluster-region/bootnodes.tf
+++ b/terraform/modules/quorum-cluster-region/bootnodes.tf
@@ -96,6 +96,9 @@ resource "aws_lb_listener" "bootnode" {
   }
 }
 
+# TODO: enodes need to be accessible via both TCP & UDP.
+# Where do I configure the UDP access here?
+
 resource "aws_lb_target_group" "bootnodes" {
   count = "${aws_launch_configuration.bootnodes.count}"
   arn = "${aws_autoscaling_group.bootnodes.*.arn}"

--- a/terraform/modules/quorum-cluster-region/bootnodes.tf
+++ b/terraform/modules/quorum-cluster-region/bootnodes.tf
@@ -32,51 +32,60 @@ resource "aws_subnet" "bootnodes" {
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
-# BOOTNODES
+# BOOTNODE LAUNCH CONFIGURATION
 # ---------------------------------------------------------------------------------------------------------------------
-resource "aws_instance" "bootnode" {
-  connection {
-    # The default username for our AMI
-    user = "ubuntu"
+resource "aws_launch_configuration" "bootnodes" {
+  count = "${data.template_file.user_data_bootnode.count}"
 
-    # The connection will use the local SSH agent for authentication if this is empty.
-    private_key = "${var.private_key}"
-  }
-
+  image_id   = "${var.bootnode_ami == "" ? data.aws_ami.bootnode.id : var.bootnode_ami}"
   instance_type = "${var.bootnode_instance_type}"
-  count         = "${lookup(var.bootnode_counts, var.aws_region, 0)}"
-
-  ami       = "${var.bootnode_ami == "" ? data.aws_ami.bootnode.id : var.bootnode_ami}"
   user_data = "${data.template_file.user_data_bootnode.rendered}"
 
   key_name = "${aws_key_pair.auth.id}"
 
   iam_instance_profile = "${aws_iam_instance_profile.bootnode.name}"
+  security_groups = ["${aws_security_group.bootnode.id}"]
 
-  vpc_security_group_ids = ["${aws_security_group.bootnode.id}"]
-  subnet_id              = "${element(aws_subnet.bootnodes.*.id, count.index)}"
-
-  tenancy = "${var.use_dedicated_bootnodes ? "dedicated" : "default"}"
-
-  tags {
-    Name = "bootnode-${count.index}"
-  }
-
-  provisioner "remote-exec" {
-    inline = [
-      "sudo apt-get -y update",
-      "echo '${aws_s3_bucket.quorum_constellation.id} /opt/quorum/constellation/private/s3fs fuse.s3fs _netdev,allow_other,iam_role 0 0' | sudo tee /etc/fstab",
-      "sudo mount -a",
-      "echo '${count.index}' | sudo tee /opt/quorum/info/index.txt",
-      "echo '${jsonencode(var.bootnode_counts)}' | sudo tee /opt/quorum/info/bootnode-counts.json",
-      "sudo python /opt/quorum/bin/fill-node-counts.py --quorum-info-root '/opt/quorum/info' --bootnode",
-      "echo '${var.aws_region}' | sudo tee /opt/quorum/info/aws-region.txt",
-      "echo '${var.primary_region}' | sudo tee /opt/quorum/info/primary-region.txt",
-      # This should be last because init scripts wait for this file to determine terraform is done provisioning
-      "echo '${var.network_id}' | sudo tee /opt/quorum/info/network-id.txt",
-    ]
-  }
+  placement_tenancy = "${var.use_dedicated_bootnodes ? "dedicated" : "default"}"
 }
+
+# ---------------------------------------------------------------------------------------------------------------------
+# BOOTNODE ASG
+# ---------------------------------------------------------------------------------------------------------------------
+resource "aws_autoscaling_group" "bootnodes" {
+  count = "${aws_launch_configuration.bootnode.count}"
+
+  name = "bootnode-net-${var.network_id}-node-${count.index}"
+
+  launch_configuration = "${element(aws_launch_configuration.bootnode.*.name, count.index)}"
+
+  min_size = 1
+  max_size = 1
+  desired_capacity = 1
+
+  health_check_grace_period = 300
+  health_check_type = "ELB"
+
+  vpc_zone_identifier = ["${element(aws_subnet.bootnodes.*.id, count.index)}"]
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# BOOTNODE LOAD BALANCER
+# ---------------------------------------------------------------------------------------------------------------------
+resource "aws_lb" "bootnode" {
+  count = "${aws_launch_configuration.bootnode.count}"
+
+  internal = false
+  load_balancer_type = "network"
+  subnets = ["${aws_subnet.bootnodes.*.id}"]
+
+  # Q?: Apparently load balancers can't be modified without deleting them(?)
+  # Examples set this to true even though default is false, not sure why
+  # enable_deletion_protection = true
+}
+
+# TODO: Attach this load balancer to the above autoscaling group.
+# Looks like I need a target_group & a listener?
 
 # ---------------------------------------------------------------------------------------------------------------------
 # THE USER DATA SCRIPT THAT WILL RUN ON EACH BOOTNODE WHEN IT'S BOOTING
@@ -84,11 +93,21 @@ resource "aws_instance" "bootnode" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 data "template_file" "user_data_bootnode" {
+
+  # Q?: This looks like it assumes only one bootnode per region, is that true?
   count = "${signum(lookup(var.bootnode_counts, var.aws_region, 0))}"
 
   template = "${file("${path.module}/user-data/user-data-bootnode.sh")}"
 
   vars {
+    constellation_s3_bucket = "${aws_s3_bucket.quorum_constellation.id}"
+    index = "${count.index}"
+    bootnode_count_json = "${data.template_file.bootnode_count_json.rendered}"
+    aws_region = "${var.aws_region}"
+    primary_region = "${var.primary_region}"
+    network_id = "${var.network_id}"
+    lb_dns = "${aws_lb.bootnodes.*.dns_name}"
+
     vault_dns  = "${var.vault_dns}"
     vault_port = "${var.vault_port}"
 

--- a/terraform/modules/quorum-cluster-region/main.tf
+++ b/terraform/modules/quorum-cluster-region/main.tf
@@ -99,6 +99,10 @@ resource "aws_iam_policy" "quorum" {
     "Effect": "Allow",
     "Action": ["dynamodb:UpdateItem"],
     "Resource": "*"
+  },{
+    "Effect": "Allow",
+    "Action": ["ec2:AssociateAddress"],
+    "Resource": "*"
   }]
 }
 EOF

--- a/terraform/modules/quorum-cluster-region/outputs.tf
+++ b/terraform/modules/quorum-cluster-region/outputs.tf
@@ -11,5 +11,5 @@ output "quorum_observer_node_dns" {
 }
 
 output "bootnode_dns" {
-  value = "${data.aws_instance.bootnode.*.public_dns}"
+  value = "${aws_eip.bootnodes.*.public_ip}"
 }

--- a/terraform/modules/quorum-cluster-region/outputs.tf
+++ b/terraform/modules/quorum-cluster-region/outputs.tf
@@ -11,5 +11,5 @@ output "quorum_observer_node_dns" {
 }
 
 output "bootnode_ips" {
-  value = "${aws_eip.bootnodes.*.public_ip}"
+  value = "${coalescelist(aws_eip.bootnodes.*.public_ip, data.aws_instance.bootnodes.*.public_ip)}"
 }

--- a/terraform/modules/quorum-cluster-region/outputs.tf
+++ b/terraform/modules/quorum-cluster-region/outputs.tf
@@ -11,5 +11,5 @@ output "quorum_observer_node_dns" {
 }
 
 output "bootnode_dns" {
-  value = "${aws_instance.bootnode.*.public_dns}"
+  value = "${data.aws_instance.bootnode.*.public_dns}"
 }

--- a/terraform/modules/quorum-cluster-region/outputs.tf
+++ b/terraform/modules/quorum-cluster-region/outputs.tf
@@ -10,6 +10,6 @@ output "quorum_observer_node_dns" {
   value = "${data.aws_instance.quorum_observer_node.*.public_dns}"
 }
 
-output "bootnode_dns" {
+output "bootnode_ips" {
   value = "${aws_eip.bootnodes.*.public_ip}"
 }

--- a/terraform/modules/quorum-cluster-region/user-data/user-data-bootnode.sh
+++ b/terraform/modules/quorum-cluster-region/user-data/user-data-bootnode.sh
@@ -58,12 +58,6 @@ function populate_data_files {
   sudo python /opt/quorum/bin/fill-node-counts.py --quorum-info-root '/opt/quorum/info' --bootnode
   echo "${aws_region}" | sudo tee /opt/quorum/info/aws-region.txt
   echo "${primary_region}" | sudo tee /opt/quorum/info/primary-region.txt
-
-  #TODO: Init scripts used to use this file to determine when provisioning is done.
-  # How do things need to change now that we don't control provisioning?
-  echo "${network_id}" | sudo tee /opt/quorum/info/network-id.txt
-
-  # Planning to have node use this for resolving public IP.
   echo "${lb_dns}" | sudo tee /opt/quorum/info/lb_dns.txt
 }
 

--- a/terraform/modules/quorum-cluster-region/user-data/user-data-bootnode.sh
+++ b/terraform/modules/quorum-cluster-region/user-data/user-data-bootnode.sh
@@ -58,7 +58,8 @@ function populate_data_files {
   sudo python /opt/quorum/bin/fill-node-counts.py --quorum-info-root '/opt/quorum/info' --bootnode
   echo "${aws_region}" | sudo tee /opt/quorum/info/aws-region.txt
   echo "${primary_region}" | sudo tee /opt/quorum/info/primary-region.txt
-  echo "${lb_dns}" | sudo tee /opt/quorum/info/lb_dns.txt
+  echo "${public_ip}" | sudo tee /opt/quorum/info/public_ip.txt
+  echo "${eip_id}" | sudo tee /opt/quorum/info/eip_id.txt
 }
 
 # Send the log output from this script to user-data.log, syslog, and the console

--- a/terraform/modules/quorum-cluster-region/user-data/user-data-bootnode.sh
+++ b/terraform/modules/quorum-cluster-region/user-data/user-data-bootnode.sh
@@ -53,8 +53,8 @@ function populate_data_files {
   sudo python /opt/quorum/bin/fill-node-counts.py --quorum-info-root '/opt/quorum/info' --bootnode
   echo "${aws_region}" | sudo tee /opt/quorum/info/aws-region.txt
   echo "${primary_region}" | sudo tee /opt/quorum/info/primary-region.txt
-  echo "${public_ip}" | sudo tee /opt/quorum/info/public_ip.txt
-  echo "${eip_id}" | sudo tee /opt/quorum/info/eip_id.txt
+  echo "${public_ip}" | sudo tee /opt/quorum/info/public-ip.txt
+  echo "${eip_id}" | sudo tee /opt/quorum/info/eip-id.txt
 }
 
 # Send the log output from this script to user-data.log, syslog, and the console

--- a/terraform/modules/quorum-cluster-region/user-data/user-data-bootnode.sh
+++ b/terraform/modules/quorum-cluster-region/user-data/user-data-bootnode.sh
@@ -47,11 +47,6 @@ function configure_threatstack_agent_if_key_provided {
   fi
 }
 
-function setup_s3fs {
-  echo "${constellation_s3_bucket} /opt/quorum/constellation/private/s3fs fuse.s3fs _netdev,allow_other,iam_role 0 0" | sudo tee /etc/fstab
-  sudo mount -a
-}
-
 function populate_data_files {
   echo "${index}" | sudo tee /opt/quorum/info/index.txt
   echo "${bootnode_count_json}" | sudo tee /opt/quorum/info/bootnode-counts.json
@@ -70,7 +65,6 @@ sudo apt-get -y update
 sudo ntpd
 
 download_vault_certs
-# setup_s3fs
 populate_data_files
 
 # These variables are passed in via Terraform template interpolation

--- a/terraform/modules/quorum-cluster-region/user-data/user-data-bootnode.sh
+++ b/terraform/modules/quorum-cluster-region/user-data/user-data-bootnode.sh
@@ -47,6 +47,26 @@ function configure_threatstack_agent_if_key_provided {
   fi
 }
 
+function setup_s3fs {
+  echo "${constellation_s3_bucket} /opt/quorum/constellation/private/s3fs fuse.s3fs _netdev,allow_other,iam_role 0 0" | sudo tee /etc/fstab
+  sudo mount -a
+}
+
+function populate_data_files {
+  echo "${index}" | sudo tee /opt/quorum/info/index.txt
+  echo "${bootnode-count-json}" | sudo tee /opt/quorum/info/bootnode-counts.json
+  sudo python /opt/quorum/bin/fill-node-counts.py --quorum-info-root '/opt/quorum/info' --bootnode
+  echo "${aws_region}" | sudo tee /opt/quorum/info/aws-region.txt
+  echo "${primary_region}" | sudo tee /opt/quorum/info/primary-region.txt
+
+  #TODO: Init scripts used to use this file to determine when provisioning is done.
+  # How do things need to change now that we don't control provisioning?
+  echo "${network_id}" | sudo tee /opt/quorum/info/network-id.txt
+
+  # Planning to have node use this for resolving public IP.
+  echo "${lb_dns}" | sudo tee /opt/quorum/info/lb_dns.txt
+}
+
 # Send the log output from this script to user-data.log, syslog, and the console
 # From: https://alestic.com/2010/12/ec2-user-data-output/
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
@@ -55,6 +75,8 @@ sudo apt-get -y update
 sudo ntpd
 
 download_vault_certs
+setup_s3fs
+populate_data_files
 
 # These variables are passed in via Terraform template interpolation
 /opt/consul/bin/run-consul --client --cluster-tag-key "${consul_cluster_tag_key}" --cluster-tag-value "${consul_cluster_tag_value}"

--- a/terraform/modules/quorum-cluster-region/user-data/user-data-bootnode.sh
+++ b/terraform/modules/quorum-cluster-region/user-data/user-data-bootnode.sh
@@ -53,6 +53,7 @@ function populate_data_files {
   sudo python /opt/quorum/bin/fill-node-counts.py --quorum-info-root '/opt/quorum/info' --bootnode
   echo "${aws_region}" | sudo tee /opt/quorum/info/aws-region.txt
   echo "${primary_region}" | sudo tee /opt/quorum/info/primary-region.txt
+  echo "${use_elastic_bootnode_ips}" | sudo tee /opt/quorum/info/using-eip.txt
   echo "${public_ip}" | sudo tee /opt/quorum/info/public-ip.txt
   echo "${eip_id}" | sudo tee /opt/quorum/info/eip-id.txt
 }

--- a/terraform/modules/quorum-cluster-region/user-data/user-data-bootnode.sh
+++ b/terraform/modules/quorum-cluster-region/user-data/user-data-bootnode.sh
@@ -54,7 +54,7 @@ function setup_s3fs {
 
 function populate_data_files {
   echo "${index}" | sudo tee /opt/quorum/info/index.txt
-  echo "${bootnode-count-json}" | sudo tee /opt/quorum/info/bootnode-counts.json
+  echo "${bootnode_count_json}" | sudo tee /opt/quorum/info/bootnode-counts.json
   sudo python /opt/quorum/bin/fill-node-counts.py --quorum-info-root '/opt/quorum/info' --bootnode
   echo "${aws_region}" | sudo tee /opt/quorum/info/aws-region.txt
   echo "${primary_region}" | sudo tee /opt/quorum/info/primary-region.txt
@@ -70,7 +70,7 @@ sudo apt-get -y update
 sudo ntpd
 
 download_vault_certs
-setup_s3fs
+# setup_s3fs
 populate_data_files
 
 # These variables are passed in via Terraform template interpolation

--- a/terraform/modules/quorum-cluster-region/variables.tf
+++ b/terraform/modules/quorum-cluster-region/variables.tf
@@ -119,6 +119,11 @@ variable "use_dedicated_observers" {
   default     = false
 }
 
+variable "use_elastic_bootnode_ips" {
+  description = "Whether or not to give bootnodes elastic IPs, maintaining one static IP forever. Disabled by default because regions with more than 5 bootnodes will require personally requesting more EIPs from AWS."
+  default     = false
+}
+
 variable "bootnode_instance_type" {
   description = "The EC2 instance type to use for bootnodes"
   default     = "t2.small"

--- a/terraform/modules/quorum-cluster/main.tf
+++ b/terraform/modules/quorum-cluster/main.tf
@@ -110,6 +110,8 @@ module "quorum_cluster_us_east_1" {
   use_dedicated_validators = "${var.use_dedicated_validators}"
   use_dedicated_observers  = "${var.use_dedicated_observers}"
 
+  use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
+
   node_volume_size = "${var.node_volume_size}"
 
   threatstack_deploy_key = "${var.threatstack_deploy_key}"
@@ -164,6 +166,8 @@ module "quorum_cluster_us_east_2" {
   use_dedicated_makers     = "${var.use_dedicated_makers}"
   use_dedicated_validators = "${var.use_dedicated_validators}"
   use_dedicated_observers  = "${var.use_dedicated_observers}"
+
+  use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
 
   node_volume_size = "${var.node_volume_size}"
 
@@ -220,6 +224,8 @@ module "quorum_cluster_us_west_1" {
   use_dedicated_validators = "${var.use_dedicated_validators}"
   use_dedicated_observers  = "${var.use_dedicated_observers}"
 
+  use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
+
   node_volume_size = "${var.node_volume_size}"
 
   threatstack_deploy_key = "${var.threatstack_deploy_key}"
@@ -274,6 +280,8 @@ module "quorum_cluster_us_west_2" {
   use_dedicated_makers     = "${var.use_dedicated_makers}"
   use_dedicated_validators = "${var.use_dedicated_validators}"
   use_dedicated_observers  = "${var.use_dedicated_observers}"
+
+  use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
 
   node_volume_size = "${var.node_volume_size}"
 
@@ -330,6 +338,8 @@ module "quorum_cluster_eu_central_1" {
   use_dedicated_validators = "${var.use_dedicated_validators}"
   use_dedicated_observers  = "${var.use_dedicated_observers}"
 
+  use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
+
   node_volume_size = "${var.node_volume_size}"
 
   threatstack_deploy_key = "${var.threatstack_deploy_key}"
@@ -384,6 +394,8 @@ module "quorum_cluster_eu_west_1" {
   use_dedicated_makers     = "${var.use_dedicated_makers}"
   use_dedicated_validators = "${var.use_dedicated_validators}"
   use_dedicated_observers  = "${var.use_dedicated_observers}"
+
+  use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
 
   node_volume_size = "${var.node_volume_size}"
 
@@ -440,6 +452,8 @@ module "quorum_cluster_eu_west_2" {
   use_dedicated_validators = "${var.use_dedicated_validators}"
   use_dedicated_observers  = "${var.use_dedicated_observers}"
 
+  use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
+
   node_volume_size = "${var.node_volume_size}"
 
   threatstack_deploy_key = "${var.threatstack_deploy_key}"
@@ -494,6 +508,8 @@ module "quorum_cluster_ap_south_1" {
   use_dedicated_makers     = "${var.use_dedicated_makers}"
   use_dedicated_validators = "${var.use_dedicated_validators}"
   use_dedicated_observers  = "${var.use_dedicated_observers}"
+
+  use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
 
   node_volume_size = "${var.node_volume_size}"
 
@@ -550,6 +566,8 @@ module "quorum_cluster_ap_northeast_1" {
   use_dedicated_validators = "${var.use_dedicated_validators}"
   use_dedicated_observers  = "${var.use_dedicated_observers}"
 
+  use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
+
   node_volume_size = "${var.node_volume_size}"
 
   threatstack_deploy_key = "${var.threatstack_deploy_key}"
@@ -604,6 +622,8 @@ module "quorum_cluster_ap_northeast_2" {
   use_dedicated_makers     = "${var.use_dedicated_makers}"
   use_dedicated_validators = "${var.use_dedicated_validators}"
   use_dedicated_observers  = "${var.use_dedicated_observers}"
+
+  use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
 
   node_volume_size = "${var.node_volume_size}"
 
@@ -660,6 +680,8 @@ module "quorum_cluster_ap_southeast_1" {
   use_dedicated_validators = "${var.use_dedicated_validators}"
   use_dedicated_observers  = "${var.use_dedicated_observers}"
 
+  use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
+
   node_volume_size = "${var.node_volume_size}"
 
   threatstack_deploy_key = "${var.threatstack_deploy_key}"
@@ -714,6 +736,8 @@ module "quorum_cluster_ap_southeast_2" {
   use_dedicated_makers     = "${var.use_dedicated_makers}"
   use_dedicated_validators = "${var.use_dedicated_validators}"
   use_dedicated_observers  = "${var.use_dedicated_observers}"
+
+  use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
 
   node_volume_size = "${var.node_volume_size}"
 
@@ -770,6 +794,8 @@ module "quorum_cluster_ca_central_1" {
   use_dedicated_validators = "${var.use_dedicated_validators}"
   use_dedicated_observers  = "${var.use_dedicated_observers}"
 
+  use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
+
   node_volume_size = "${var.node_volume_size}"
 
   threatstack_deploy_key = "${var.threatstack_deploy_key}"
@@ -824,6 +850,8 @@ module "quorum_cluster_sa_east_1" {
   use_dedicated_makers     = "${var.use_dedicated_makers}"
   use_dedicated_validators = "${var.use_dedicated_validators}"
   use_dedicated_observers  = "${var.use_dedicated_observers}"
+
+  use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
 
   node_volume_size = "${var.node_volume_size}"
 

--- a/terraform/modules/quorum-cluster/outputs.tf
+++ b/terraform/modules/quorum-cluster/outputs.tf
@@ -55,22 +55,22 @@ output "quorum_observer_node_dns" {
   }
 }
 
-output "bootnode_dns" {
+output "bootnode_ips" {
   value = {
-    us-east-1      = "${module.quorum_cluster_us_east_1.bootnode_dns}"
-    us-east-2      = "${module.quorum_cluster_us_east_2.bootnode_dns}"
-    us-west-1      = "${module.quorum_cluster_us_west_1.bootnode_dns}"
-    us-west-2      = "${module.quorum_cluster_us_west_2.bootnode_dns}"
-    eu-central-1   = "${module.quorum_cluster_eu_central_1.bootnode_dns}"
-    eu-west-1      = "${module.quorum_cluster_eu_west_1.bootnode_dns}"
-    eu-west-2      = "${module.quorum_cluster_eu_west_2.bootnode_dns}"
-    ap-south-1     = "${module.quorum_cluster_ap_south_1.bootnode_dns}"
-    ap-northeast-1 = "${module.quorum_cluster_ap_northeast_1.bootnode_dns}"
-    ap-northeast-2 = "${module.quorum_cluster_ap_northeast_2.bootnode_dns}"
-    ap-southeast-1 = "${module.quorum_cluster_ap_southeast_1.bootnode_dns}"
-    ap-southeast-2 = "${module.quorum_cluster_ap_southeast_2.bootnode_dns}"
-    ca-central-1   = "${module.quorum_cluster_ca_central_1.bootnode_dns}"
-    sa-east-1      = "${module.quorum_cluster_sa_east_1.bootnode_dns}"
+    us-east-1      = "${module.quorum_cluster_us_east_1.bootnode_ips}"
+    us-east-2      = "${module.quorum_cluster_us_east_2.bootnode_ips}"
+    us-west-1      = "${module.quorum_cluster_us_west_1.bootnode_ips}"
+    us-west-2      = "${module.quorum_cluster_us_west_2.bootnode_ips}"
+    eu-central-1   = "${module.quorum_cluster_eu_central_1.bootnode_ips}"
+    eu-west-1      = "${module.quorum_cluster_eu_west_1.bootnode_ips}"
+    eu-west-2      = "${module.quorum_cluster_eu_west_2.bootnode_ips}"
+    ap-south-1     = "${module.quorum_cluster_ap_south_1.bootnode_ips}"
+    ap-northeast-1 = "${module.quorum_cluster_ap_northeast_1.bootnode_ips}"
+    ap-northeast-2 = "${module.quorum_cluster_ap_northeast_2.bootnode_ips}"
+    ap-southeast-1 = "${module.quorum_cluster_ap_southeast_1.bootnode_ips}"
+    ap-southeast-2 = "${module.quorum_cluster_ap_southeast_2.bootnode_ips}"
+    ca-central-1   = "${module.quorum_cluster_ca_central_1.bootnode_ips}"
+    sa-east-1      = "${module.quorum_cluster_sa_east_1.bootnode_ips}"
   }
 }
 

--- a/terraform/modules/quorum-cluster/variables.tf
+++ b/terraform/modules/quorum-cluster/variables.tf
@@ -127,6 +127,11 @@ variable "use_dedicated_consul_servers" {
   default     = false
 }
 
+variable "use_elastic_bootnode_ips" {
+  description = "Whether or not to give bootnodes elastic IPs, maintaining one static IP forever. Disabled by default because clusters with more than 5 bootnodes in one region will require personally requesting more EIPs from AWS."
+  default     = false
+}
+
 variable "cert_org_name" {
   description = "The organization to associate with the vault certificates."
   default     = "Example Co."

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -10,8 +10,8 @@ output "quorum_observer_node_dns" {
   value = "${module.quorum_cluster.quorum_observer_node_dns}"
 }
 
-output "bootnode_dns" {
-  value = "${module.quorum_cluster.bootnode_dns}"
+output "bootnode_ips" {
+  value = "${module.quorum_cluster.bootnode_ips}"
 }
 
 output "vault_server_ips" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -112,6 +112,11 @@ variable "use_dedicated_consul_servers" {
   default     = false
 }
 
+variable "use_elastic_bootnode_ips" {
+  description = "Whether or not to give bootnodes elastic IPs, maintaining one static IP forever. Disabled by default because clusters with more than 5 bootnodes in one region will require personally requesting more EIPs from AWS."
+  default     = false
+}
+
 variable "cert_org_name" {
   description = "The organization to associate with the vault certificates."
   default     = "Example Co."


### PR DESCRIPTION
This PR refactors bootnodes from directly using AWS instances to instead use an autoscaling group, so that bootnodes are automatically replaced when they fail.  In order to ensure they have a static IP, we also use elastic IPs which are provisioned at `terraform apply` and are then associated to each autoscaling group's node within the `init-bootnode.sh` script.

- Code has been tested on a unit test net (1-1-1-1 in us-east-1), private transactions were successful.
- The bootnode DNS names returned by terraform data providers now fails, as claiming a new IP address also changes the bootnodes' DNS names.  Solution was to use the permanent IP in key places where the hostname was being used (writing to Vault & the terraform output).
- Added a new permission, all nodes are able to claim any address.  This technically allows an attacker with access to one bootnode to make the rest of them inaccessible by claiming all of their IPs.  However, re-running `terraform apply` ought to re-associate each node with its proper address.
- If somebody launches a network with more than 5 bootnodes in this version, AWS will throw an error requiring that they request more elastic IPs.  Our proposed solution there was to have EIP functionality disabled by default, that is not implemented in this PR.  Based on the number of changes required here, I wanted to sit down and talk about the right way to make this functionality optional.