### PR TITLE
Name tweak for regional buckets

### DIFF
--- a/terraform/modules/quorum-cluster-region/main.tf
+++ b/terraform/modules/quorum-cluster-region/main.tf
@@ -34,7 +34,7 @@ resource "aws_key_pair" "auth" {
 resource "aws_s3_bucket" "quorum_constellation" {
   count = "${signum(lookup(var.bootnode_counts, var.aws_region, 0) + lookup(var.maker_node_counts, var.aws_region, 0) + lookup(var.validator_node_counts, var.aws_region, 0) + lookup(var.observer_node_counts, var.aws_region, 0))}"
 
-  bucket_prefix = "quorum-constellation-network-${var.network_id}-"
+  bucket_prefix = "quorum-constellation-${var.aws_region}-network-${var.network_id}-"
   force_destroy = "${var.force_destroy_s3_buckets}"
 }
 
@@ -44,7 +44,7 @@ resource "aws_s3_bucket" "quorum_constellation" {
 resource "aws_s3_bucket" "quorum_backup" {
   count = "${signum(lookup(var.bootnode_counts, var.aws_region, 0) + lookup(var.maker_node_counts, var.aws_region, 0) + lookup(var.validator_node_counts, var.aws_region, 0) + lookup(var.observer_node_counts, var.aws_region, 0))}"
 
-  bucket_prefix = "quorum-backup-network-${var.network_id}-"
+  bucket_prefix = "quorum-backup-${var.aws_region}-network-${var.network_id}-"
   force_destroy = "${var.force_destroy_s3_buckets}"
 }
 


### PR DESCRIPTION
Nothing big here, just added the region to the names for the two S3 buckets in `quorum-cluster-region/main.tf` (the ones for Constellation payload & regional backups).