### PR TITLE
Fixes for duplicated othernodes, date/time logging for crashcloudwatch and buffer_size for init-quorum

### DIFF
--- a/packer/instance-scripts/crashcloudwatch.py
+++ b/packer/instance-scripts/crashcloudwatch.py
@@ -93,6 +93,7 @@ class CrashCloudWatch:
         self.client = boto3.client('cloudwatch', region_name=read_primary_region())
 
     def runforever(self, test=False):
+        YMDHMS = "%Y-%m-%d_%H:%M:%S"
         while 1:
             # we explicitly use self.stdin, self.stdout, and self.stderr
             # instead of sys.* so we can unit test this code
@@ -103,7 +104,7 @@ class CrashCloudWatch:
                 # do nothing with non-TICK events
                 childutils.listener.ok(self.stdout)
                 if test:
-                    self.stderr.write(datetime.now().strftime("%Y-%m-%d_%H:%M:%S") + ' non-exited event\n')
+                    self.stderr.write(datetime.now().strftime(YMDHMS) + ' non-exited event\n')
                     self.stderr.flush()
                     break
                 continue
@@ -113,12 +114,12 @@ class CrashCloudWatch:
             if int(pheaders['expected']):
                 childutils.listener.ok(self.stdout)
                 if test:
-                    self.stderr.write(datetime.now().strftime("%Y-%m-%d_%H:%M:%S") + ' expected exit\n')
+                    self.stderr.write(datetime.now().strftime(YMDHMS) + ' expected exit\n')
                     self.stderr.flush()
                     break
                 continue
 
-            self.stderr.write(datetime.now().strftime("%Y-%m-%d_%H:%M:%S") + ' unexpected exit, emitting cloudwatch metric\n')
+            self.stderr.write(datetime.now().strftime(YMDHMS) + ' unexpected exit, emitting cloudwatch metric\n')
             self.stderr.flush()
 
             self.emit_metric(self.metric)

--- a/packer/instance-scripts/crashcloudwatch.py
+++ b/packer/instance-scripts/crashcloudwatch.py
@@ -57,8 +57,8 @@ import getopt
 import os
 import sys
 import boto3
-import datetime
 
+from datetime import datetime
 from supervisor import childutils
 
 
@@ -103,7 +103,7 @@ class CrashCloudWatch:
                 # do nothing with non-TICK events
                 childutils.listener.ok(self.stdout)
                 if test:
-                    self.stderr.write(datetime.datetime.now().strftime("%Y-%m-%d_%H:%M:%S") + ' non-exited event\n')
+                    self.stderr.write(datetime.now().strftime("%Y-%m-%d_%H:%M:%S") + ' non-exited event\n')
                     self.stderr.flush()
                     break
                 continue
@@ -113,12 +113,12 @@ class CrashCloudWatch:
             if int(pheaders['expected']):
                 childutils.listener.ok(self.stdout)
                 if test:
-                    self.stderr.write(datetime.datetime.now().strftime("%Y-%m-%d_%H:%M:%S") + ' expected exit\n')
+                    self.stderr.write(datetime.now().strftime("%Y-%m-%d_%H:%M:%S") + ' expected exit\n')
                     self.stderr.flush()
                     break
                 continue
 
-            self.stderr.write(datetime.datetime.now().strftime("%Y-%m-%d_%H:%M:%S") + ' unexpected exit, emitting cloudwatch metric\n')
+            self.stderr.write(datetime.now().strftime("%Y-%m-%d_%H:%M:%S") + ' unexpected exit, emitting cloudwatch metric\n')
             self.stderr.flush()
 
             self.emit_metric(self.metric)

--- a/packer/instance-scripts/crashcloudwatch.py
+++ b/packer/instance-scripts/crashcloudwatch.py
@@ -57,6 +57,7 @@ import getopt
 import os
 import sys
 import boto3
+import datetime
 
 from supervisor import childutils
 
@@ -102,7 +103,7 @@ class CrashCloudWatch:
                 # do nothing with non-TICK events
                 childutils.listener.ok(self.stdout)
                 if test:
-                    self.stderr.write('non-exited event\n')
+                    self.stderr.write(datetime.datetime.now().strftime("%Y-%m-%d_%H:%M:%S") + ' non-exited event\n')
                     self.stderr.flush()
                     break
                 continue
@@ -112,12 +113,12 @@ class CrashCloudWatch:
             if int(pheaders['expected']):
                 childutils.listener.ok(self.stdout)
                 if test:
-                    self.stderr.write('expected exit\n')
+                    self.stderr.write(datetime.datetime.now().strftime("%Y-%m-%d_%H:%M:%S") + ' expected exit\n')
                     self.stderr.flush()
                     break
                 continue
 
-            self.stderr.write('unexpected exit, emitting cloudwatch metric\n')
+            self.stderr.write(datetime.datetime.now().strftime("%Y-%m-%d_%H:%M:%S") + ' unexpected exit, emitting cloudwatch metric\n')
             self.stderr.flush()
 
             self.emit_metric(self.metric)

--- a/packer/instance-scripts/init-bootnode.sh
+++ b/packer/instance-scripts/init-bootnode.sh
@@ -20,8 +20,8 @@ function complete_constellation_config {
 
     local REGIONS=$(cat /opt/quorum/info/regions.txt)
 
-    DIR=$(dirname "${CONSTELLATION_CONFIG_PATH}")
-    FLAGFILE="$DIR/constellation.done"
+    local DIR=$(dirname "${CONSTELLATION_CONFIG_PATH}")
+    local FLAGFILE="$DIR/constellation.done"
 
     if [ ! -f $FLAGFILE ]
     then

--- a/packer/instance-scripts/init-quorum.sh
+++ b/packer/instance-scripts/init-quorum.sh
@@ -65,6 +65,7 @@ numprocs=1
 autostart=true
 autorestart=false
 stopsignal=INT
+exitcodes=0,1,2
 user=ubuntu" | sudo tee /etc/supervisor/conf.d/quorum-supervisor.conf
 }
 
@@ -79,6 +80,7 @@ autostart=true
 autorestart=unexpected
 stopsignal=QUIT
 user=ubuntu
+buffer_size=1024
 events=PROCESS_STATE" | sudo tee /etc/supervisor/conf.d/crashquorum-supervisor.conf
 }
 
@@ -93,6 +95,7 @@ autostart=true
 autorestart=unexpected
 stopsignal=QUIT
 user=ubuntu
+buffer_size=1024
 events=PROCESS_STATE" | sudo tee /etc/supervisor/conf.d/crashconstellation-supervisor.conf
 }
 


### PR DESCRIPTION
Added datetime to crashcloudwatch and exitcodes to quorum, so that crashquorum doesn't emit a cloudwatch when quorum is stopped by supervisorctl.