### PR TITLE
Elastic IPs for observer nodes

### DIFF
--- a/packer/instance-scripts/init-quorum.sh
+++ b/packer/instance-scripts/init-quorum.sh
@@ -274,21 +274,9 @@ function wait_for_terraform_provisioners {
     done
 }
 
-# Wait for operator to initialize and unseal vault
-wait_for_successful_command 'vault init -check'
-wait_for_successful_command 'vault status'
-
-# Wait for vault to be fully configured by the root user
-wait_for_successful_command 'vault auth -method=aws'
-
-wait_for_terraform_provisioners
-
-# Get the region and overall index for this instance
-CLUSTER_INDEX=$(cat /opt/quorum/info/overall-index.txt)
-AWS_REGION=$(cat /opt/quorum/info/aws-region.txt)
-
 # If using EIPs, associate with instance
 USING_EIP=$(cat /opt/quorum/info/using-eip.txt)
+AWS_REGION=$(cat /opt/quorum/info/aws-region.txt)
 if [ "$USING_EIP" == "1" ]
 then
     EIP_ID=$(cat /opt/quorum/info/eip-id.txt)
@@ -301,6 +289,18 @@ else
     echo ">> FATAL ERROR: USING_EIP needs to be boolean with value 0 or 1, instead has value $USING_EIP.  Erroring out."
     exit 1
 fi
+
+# Wait for operator to initialize and unseal vault
+wait_for_successful_command 'vault init -check'
+wait_for_successful_command 'vault status'
+
+# Wait for vault to be fully configured by the root user
+wait_for_successful_command 'vault auth -method=aws'
+
+wait_for_terraform_provisioners
+
+# Get the overall index for this instance
+CLUSTER_INDEX=$(cat /opt/quorum/info/overall-index.txt)
 
 # Load Address, Password, and Key if we already generated them or generate new ones if none exist
 ADDRESS=$(vault read -field=address quorum/addresses/$AWS_REGION/$CLUSTER_INDEX)

--- a/packer/instance-scripts/init-quorum.sh
+++ b/packer/instance-scripts/init-quorum.sh
@@ -287,6 +287,22 @@ wait_for_terraform_provisioners
 CLUSTER_INDEX=$(cat /opt/quorum/info/overall-index.txt)
 AWS_REGION=$(cat /opt/quorum/info/aws-region.txt)
 
+# If using EIPs, associate with instance
+PUBLIC_IP=$(cat /opt/quorum/info/public-ip.txt)
+USING_EIP=$(cat /opt/quorum/info/using-eip.txt)
+if [ "$USING_EIP" == "1" ]
+then
+    EIP_ID=$(cat /opt/quorum/info/eip-id.txt)
+    INSTANCE_ID=$(wait_for_successful_command 'curl -s http://169.254.169.254/latest/meta-data/instance-id')
+    wait_for_successful_command "aws ec2 associate-address --instance-id $INSTANCE_ID --allocation-id $EIP_ID --region $AWS_REGION --allow-reassociation"
+elif [ "$USING_EIP"  == "0" ]
+then
+    PUBLIC_IP=$(wait_for_successful_command 'curl -s http://169.254.169.254/latest/meta-data/public-ipv4')
+else 
+    echo ">> FATAL ERROR: USING_EIP needs to be boolean with value 0 or 1, instead has value $USING_EIP.  Erroring out."
+    exit 1
+fi
+
 # Load Address, Password, and Key if we already generated them or generate new ones if none exist
 ADDRESS=$(vault read -field=address quorum/addresses/$AWS_REGION/$CLUSTER_INDEX)
 if [ $? -eq 0 ]
@@ -342,7 +358,7 @@ broadcast_role_info $ROLE $AWS_REGION
 
 # Write key and address into the vault
 wait_for_successful_command "vault write quorum/keys/$AWS_REGION/$CLUSTER_INDEX geth_key=$PRIV_KEY geth_key_file=$PRIV_KEY_FILENAME constellation_priv_key=$CONSTELLATION_PRIV_KEY"
-wait_for_successful_command "vault write quorum/addresses/$AWS_REGION/$CLUSTER_INDEX address=$ADDRESS constellation_pub_key=$CONSTELLATION_PUB_KEY hostname=$HOSTNAME"
+wait_for_successful_command "vault write quorum/addresses/$AWS_REGION/$CLUSTER_INDEX address=$ADDRESS constellation_pub_key=$CONSTELLATION_PUB_KEY hostname=$PUBLIC_IP"
 
 # Wait for all nodes to write their address to vault
 wait_for_all_nodes

--- a/packer/instance-scripts/init-quorum.sh
+++ b/packer/instance-scripts/init-quorum.sh
@@ -275,8 +275,8 @@ function wait_for_terraform_provisioners {
 }
 
 function associate_elastic_ip {
-    load readonly AWS_REGION=$1
-    USING_EIP=$(cat /opt/quorum/info/using-eip.txt)
+    local readonly AWS_REGION=$1
+    local readonly USING_EIP=$(cat /opt/quorum/info/using-eip.txt)
     if [ "$USING_EIP" == "1" ]
     then
         EIP_ID=$(cat /opt/quorum/info/eip-id.txt)

--- a/packer/instance-scripts/init-quorum.sh
+++ b/packer/instance-scripts/init-quorum.sh
@@ -288,7 +288,6 @@ CLUSTER_INDEX=$(cat /opt/quorum/info/overall-index.txt)
 AWS_REGION=$(cat /opt/quorum/info/aws-region.txt)
 
 # If using EIPs, associate with instance
-PUBLIC_IP=$(cat /opt/quorum/info/public-ip.txt)
 USING_EIP=$(cat /opt/quorum/info/using-eip.txt)
 if [ "$USING_EIP" == "1" ]
 then
@@ -297,7 +296,7 @@ then
     wait_for_successful_command "aws ec2 associate-address --instance-id $INSTANCE_ID --allocation-id $EIP_ID --region $AWS_REGION --allow-reassociation"
 elif [ "$USING_EIP"  == "0" ]
 then
-    PUBLIC_IP=$(wait_for_successful_command 'curl -s http://169.254.169.254/latest/meta-data/public-ipv4')
+    # If not using EIPs, then no action required based on this boolean
 else 
     echo ">> FATAL ERROR: USING_EIP needs to be boolean with value 0 or 1, instead has value $USING_EIP.  Erroring out."
     exit 1
@@ -358,7 +357,7 @@ broadcast_role_info $ROLE $AWS_REGION
 
 # Write key and address into the vault
 wait_for_successful_command "vault write quorum/keys/$AWS_REGION/$CLUSTER_INDEX geth_key=$PRIV_KEY geth_key_file=$PRIV_KEY_FILENAME constellation_priv_key=$CONSTELLATION_PRIV_KEY"
-wait_for_successful_command "vault write quorum/addresses/$AWS_REGION/$CLUSTER_INDEX address=$ADDRESS constellation_pub_key=$CONSTELLATION_PUB_KEY hostname=$PUBLIC_IP"
+wait_for_successful_command "vault write quorum/addresses/$AWS_REGION/$CLUSTER_INDEX address=$ADDRESS constellation_pub_key=$CONSTELLATION_PUB_KEY hostname=$HOSTNAME"
 
 # Wait for all nodes to write their address to vault
 wait_for_all_nodes

--- a/packer/instance-scripts/init-quorum.sh
+++ b/packer/instance-scripts/init-quorum.sh
@@ -274,21 +274,26 @@ function wait_for_terraform_provisioners {
     done
 }
 
+function associate_elastic_ip {
+    load readonly AWS_REGION=$1
+    USING_EIP=$(cat /opt/quorum/info/using-eip.txt)
+    if [ "$USING_EIP" == "1" ]
+    then
+        EIP_ID=$(cat /opt/quorum/info/eip-id.txt)
+        INSTANCE_ID=$(wait_for_successful_command 'curl -s http://169.254.169.254/latest/meta-data/instance-id')
+        wait_for_successful_command "aws ec2 associate-address --instance-id $INSTANCE_ID --allocation-id $EIP_ID --region $AWS_REGION --allow-reassociation"
+    elif [ "$USING_EIP"  == "0" ]
+    then
+        # If not using EIPs, then no action required based on this boolean
+    else 
+        echo ">> FATAL ERROR: USING_EIP needs to be boolean with value 0 or 1, instead has value $USING_EIP.  Erroring out."
+        exit 1
+    fi
+}
+
 # If using EIPs, associate with instance
-USING_EIP=$(cat /opt/quorum/info/using-eip.txt)
 AWS_REGION=$(cat /opt/quorum/info/aws-region.txt)
-if [ "$USING_EIP" == "1" ]
-then
-    EIP_ID=$(cat /opt/quorum/info/eip-id.txt)
-    INSTANCE_ID=$(wait_for_successful_command 'curl -s http://169.254.169.254/latest/meta-data/instance-id')
-    wait_for_successful_command "aws ec2 associate-address --instance-id $INSTANCE_ID --allocation-id $EIP_ID --region $AWS_REGION --allow-reassociation"
-elif [ "$USING_EIP"  == "0" ]
-then
-    # If not using EIPs, then no action required based on this boolean
-else 
-    echo ">> FATAL ERROR: USING_EIP needs to be boolean with value 0 or 1, instead has value $USING_EIP.  Erroring out."
-    exit 1
-fi
+associate_elastic_ip $AWS_REGION
 
 # Wait for operator to initialize and unseal vault
 wait_for_successful_command 'vault init -check'

--- a/terraform/example.tfvars
+++ b/terraform/example.tfvars
@@ -14,6 +14,7 @@ use_dedicated_observers        = false
 use_dedicated_vault_servers    = false
 use_dedicated_consul_servers   = false
 use_elastic_bootnode_ips       = false
+use_elastic_observer_ips       = false
 vault_cluster_size             = 1
 vault_instance_type            = "t2.small"
 consul_cluster_size            = 1

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -26,6 +26,7 @@ module "quorum_cluster" {
   use_dedicated_vault_servers       = "${var.use_dedicated_vault_servers}"
   use_dedicated_consul_servers      = "${var.use_dedicated_consul_servers}"
   use_elastic_bootnode_ips          = "${var.use_elastic_bootnode_ips}"
+  use_elastic_observer_ips          = "${var.use_elastic_observer_ips}"
   ssh_ips                           = "${var.ssh_ips}"
   other_validator_connection_ips    = "${var.other_validator_connection_ips}"
   quorum_vpc_base_cidr              = "${var.quorum_vpc_base_cidr}"

--- a/terraform/modules/quorum-cluster-region/outputs.tf
+++ b/terraform/modules/quorum-cluster-region/outputs.tf
@@ -10,8 +10,8 @@ output "quorum_validator_node_dns" {
   value = "${data.aws_instance.quorum_validator_node.*.public_dns}"
 }
 
-output "quorum_observer_node_dns" {
-  value = "${data.aws_instance.quorum_observer_node.*.public_dns}"
+output "quorum_observer_node_ips" {
+  value = "${coalescelist(aws_eip.quorum_observer.*.public_ip, data.aws_instance.quorum_observer_node.*.public_ip)}"
 }
 
 output "bootnode_ips" {

--- a/terraform/modules/quorum-cluster-region/user-data/user-data-quorum.sh
+++ b/terraform/modules/quorum-cluster-region/user-data/user-data-quorum.sh
@@ -104,6 +104,9 @@ function populate_data_files {
   echo "${network_id}" | sudo tee /opt/quorum/info/network-id.txt
   echo "https://${vault_dns}:${vault_port}" | sudo tee /opt/quorum/info/vault-address.txt
   echo "ipc:$GETH_IPC_PATH_LOCAL" | sudo tee /opt/quorum/info/geth-ipc.txt
+  echo "${use_elastic_observer_ips}" | sudo tee /opt/quorum/info/using-eip.txt
+  echo "${public_ip}" | sudo tee /opt/quorum/info/public-ip.txt
+  echo "${eip_id}" | sudo tee /opt/quorum/info/eip-id.txt
 
   # Download node counts
   aws configure set s3.signature_version s3v4

--- a/terraform/modules/quorum-cluster-region/variables.tf
+++ b/terraform/modules/quorum-cluster-region/variables.tf
@@ -139,7 +139,12 @@ variable "use_dedicated_observers" {
 }
 
 variable "use_elastic_bootnode_ips" {
-  description = "Whether or not to give bootnodes elastic IPs, maintaining one static IP forever. Disabled by default because regions with more than 5 bootnodes will require personally requesting more EIPs from AWS. WARNING: UNTESTED SINCE MOVING BOOTNODES INTO QUORUM VPC. MAY BE REMOVED IN A FUTURE UPDATE."
+  description = "Whether or not to give bootnodes elastic IPs, maintaining one static IP forever. Disabled by default because regions with more than 5 nodes in one region using elastic IPs will require personally requesting more EIPs from AWS. WARNING: UNTESTED SINCE MOVING BOOTNODES INTO QUORUM VPC. MAY BE REMOVED IN A FUTURE UPDATE."
+  default     = false
+}
+
+variable "use_elastic_observer_ips" {
+  description = "Whether or not to give observers elastic IPs, maintaining one static IP forever. Disabled by default because clusters with more than 5 nodes in one region using elastic IPs will require personally requesting more EIPs from AWS."
   default     = false
 }
 

--- a/terraform/modules/quorum-cluster/main.tf
+++ b/terraform/modules/quorum-cluster/main.tf
@@ -278,6 +278,7 @@ module "quorum_cluster_us_east_1" {
   use_dedicated_observers  = "${var.use_dedicated_observers}"
 
   use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
+  use_elastic_observer_ips = "${var.use_elastic_observer_ips}"
 
   ssh_ips                        = "${var.ssh_ips}"
   other_validator_connection_ips = "${var.other_validator_connection_ips}"
@@ -398,6 +399,7 @@ module "quorum_cluster_us_east_2" {
   use_dedicated_observers  = "${var.use_dedicated_observers}"
 
   use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
+  use_elastic_observer_ips = "${var.use_elastic_observer_ips}"
 
   ssh_ips                        = "${var.ssh_ips}"
   other_validator_connection_ips = "${var.other_validator_connection_ips}"
@@ -518,6 +520,7 @@ module "quorum_cluster_us_west_1" {
   use_dedicated_observers  = "${var.use_dedicated_observers}"
 
   use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
+  use_elastic_observer_ips = "${var.use_elastic_observer_ips}"
 
   ssh_ips                        = "${var.ssh_ips}"
   other_validator_connection_ips = "${var.other_validator_connection_ips}"
@@ -638,6 +641,7 @@ module "quorum_cluster_us_west_2" {
   use_dedicated_observers  = "${var.use_dedicated_observers}"
 
   use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
+  use_elastic_observer_ips = "${var.use_elastic_observer_ips}"
 
   ssh_ips                        = "${var.ssh_ips}"
   other_validator_connection_ips = "${var.other_validator_connection_ips}"
@@ -758,6 +762,7 @@ module "quorum_cluster_eu_central_1" {
   use_dedicated_observers  = "${var.use_dedicated_observers}"
 
   use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
+  use_elastic_observer_ips = "${var.use_elastic_observer_ips}"
 
   ssh_ips                        = "${var.ssh_ips}"
   other_validator_connection_ips = "${var.other_validator_connection_ips}"
@@ -878,6 +883,7 @@ module "quorum_cluster_eu_west_1" {
   use_dedicated_observers  = "${var.use_dedicated_observers}"
 
   use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
+  use_elastic_observer_ips = "${var.use_elastic_observer_ips}"
 
   ssh_ips                        = "${var.ssh_ips}"
   other_validator_connection_ips = "${var.other_validator_connection_ips}"
@@ -998,6 +1004,7 @@ module "quorum_cluster_eu_west_2" {
   use_dedicated_observers  = "${var.use_dedicated_observers}"
 
   use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
+  use_elastic_observer_ips = "${var.use_elastic_observer_ips}"
 
   ssh_ips                        = "${var.ssh_ips}"
   other_validator_connection_ips = "${var.other_validator_connection_ips}"
@@ -1118,6 +1125,7 @@ module "quorum_cluster_ap_south_1" {
   use_dedicated_observers  = "${var.use_dedicated_observers}"
 
   use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
+  use_elastic_observer_ips = "${var.use_elastic_observer_ips}"
 
   ssh_ips                        = "${var.ssh_ips}"
   other_validator_connection_ips = "${var.other_validator_connection_ips}"
@@ -1238,6 +1246,7 @@ module "quorum_cluster_ap_northeast_1" {
   use_dedicated_observers  = "${var.use_dedicated_observers}"
 
   use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
+  use_elastic_observer_ips = "${var.use_elastic_observer_ips}"
 
   ssh_ips                        = "${var.ssh_ips}"
   other_validator_connection_ips = "${var.other_validator_connection_ips}"
@@ -1358,6 +1367,7 @@ module "quorum_cluster_ap_northeast_2" {
   use_dedicated_observers  = "${var.use_dedicated_observers}"
 
   use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
+  use_elastic_observer_ips = "${var.use_elastic_observer_ips}"
 
   ssh_ips                        = "${var.ssh_ips}"
   other_validator_connection_ips = "${var.other_validator_connection_ips}"
@@ -1478,6 +1488,7 @@ module "quorum_cluster_ap_southeast_1" {
   use_dedicated_observers  = "${var.use_dedicated_observers}"
 
   use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
+  use_elastic_observer_ips = "${var.use_elastic_observer_ips}"
 
   ssh_ips                        = "${var.ssh_ips}"
   other_validator_connection_ips = "${var.other_validator_connection_ips}"
@@ -1598,6 +1609,7 @@ module "quorum_cluster_ap_southeast_2" {
   use_dedicated_observers  = "${var.use_dedicated_observers}"
 
   use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
+  use_elastic_observer_ips = "${var.use_elastic_observer_ips}"
 
   ssh_ips                        = "${var.ssh_ips}"
   other_validator_connection_ips = "${var.other_validator_connection_ips}"
@@ -1718,6 +1730,7 @@ module "quorum_cluster_ca_central_1" {
   use_dedicated_observers  = "${var.use_dedicated_observers}"
 
   use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
+  use_elastic_observer_ips = "${var.use_elastic_observer_ips}"
 
   ssh_ips                        = "${var.ssh_ips}"
   other_validator_connection_ips = "${var.other_validator_connection_ips}"
@@ -1838,6 +1851,7 @@ module "quorum_cluster_sa_east_1" {
   use_dedicated_observers  = "${var.use_dedicated_observers}"
 
   use_elastic_bootnode_ips = "${var.use_elastic_bootnode_ips}"
+  use_elastic_observer_ips = "${var.use_elastic_observer_ips}"
 
   ssh_ips                        = "${var.ssh_ips}"
   other_validator_connection_ips = "${var.other_validator_connection_ips}"

--- a/terraform/modules/quorum-cluster/outputs.tf
+++ b/terraform/modules/quorum-cluster/outputs.tf
@@ -36,22 +36,22 @@ output "quorum_validator_node_dns" {
   }
 }
 
-output "quorum_observer_node_dns" {
+output "quorum_observer_node_ips" {
   value = {
-    us-east-1      = "${module.quorum_cluster_us_east_1.quorum_observer_node_dns}"
-    us-east-2      = "${module.quorum_cluster_us_east_2.quorum_observer_node_dns}"
-    us-west-1      = "${module.quorum_cluster_us_west_1.quorum_observer_node_dns}"
-    us-west-2      = "${module.quorum_cluster_us_west_2.quorum_observer_node_dns}"
-    eu-central-1   = "${module.quorum_cluster_eu_central_1.quorum_observer_node_dns}"
-    eu-west-1      = "${module.quorum_cluster_eu_west_1.quorum_observer_node_dns}"
-    eu-west-2      = "${module.quorum_cluster_eu_west_2.quorum_observer_node_dns}"
-    ap-south-1     = "${module.quorum_cluster_ap_south_1.quorum_observer_node_dns}"
-    ap-northeast-1 = "${module.quorum_cluster_ap_northeast_1.quorum_observer_node_dns}"
-    ap-northeast-2 = "${module.quorum_cluster_ap_northeast_2.quorum_observer_node_dns}"
-    ap-southeast-1 = "${module.quorum_cluster_ap_southeast_1.quorum_observer_node_dns}"
-    ap-southeast-2 = "${module.quorum_cluster_ap_southeast_2.quorum_observer_node_dns}"
-    ca-central-1   = "${module.quorum_cluster_ca_central_1.quorum_observer_node_dns}"
-    sa-east-1      = "${module.quorum_cluster_sa_east_1.quorum_observer_node_dns}"
+    us-east-1      = "${module.quorum_cluster_us_east_1.quorum_observer_node_ips}"
+    us-east-2      = "${module.quorum_cluster_us_east_2.quorum_observer_node_ips}"
+    us-west-1      = "${module.quorum_cluster_us_west_1.quorum_observer_node_ips}"
+    us-west-2      = "${module.quorum_cluster_us_west_2.quorum_observer_node_ips}"
+    eu-central-1   = "${module.quorum_cluster_eu_central_1.quorum_observer_node_ips}"
+    eu-west-1      = "${module.quorum_cluster_eu_west_1.quorum_observer_node_ips}"
+    eu-west-2      = "${module.quorum_cluster_eu_west_2.quorum_observer_node_ips}"
+    ap-south-1     = "${module.quorum_cluster_ap_south_1.quorum_observer_node_ips}"
+    ap-northeast-1 = "${module.quorum_cluster_ap_northeast_1.quorum_observer_node_ips}"
+    ap-northeast-2 = "${module.quorum_cluster_ap_northeast_2.quorum_observer_node_ips}"
+    ap-southeast-1 = "${module.quorum_cluster_ap_southeast_1.quorum_observer_node_ips}"
+    ap-southeast-2 = "${module.quorum_cluster_ap_southeast_2.quorum_observer_node_ips}"
+    ca-central-1   = "${module.quorum_cluster_ca_central_1.quorum_observer_node_ips}"
+    sa-east-1      = "${module.quorum_cluster_sa_east_1.quorum_observer_node_ips}"
   }
 }
 

--- a/terraform/modules/quorum-cluster/variables.tf
+++ b/terraform/modules/quorum-cluster/variables.tf
@@ -132,7 +132,12 @@ variable "use_dedicated_consul_servers" {
 }
 
 variable "use_elastic_bootnode_ips" {
-  description = "Whether or not to give bootnodes elastic IPs, maintaining one static IP forever. Disabled by default because clusters with more than 5 bootnodes in one region will require personally requesting more EIPs from AWS. WARNING: UNTESTED SINCE MOVING BOOTNODES INTO QUORUM VPC. MAY BE REMOVED IN A FUTURE UPDATE."
+  description = "Whether or not to give bootnodes elastic IPs, maintaining one static IP forever. Disabled by default because clusters with more than 5 nodes in one region using elastic IPs will require personally requesting more EIPs from AWS. WARNING: UNTESTED SINCE MOVING BOOTNODES INTO QUORUM VPC. MAY BE REMOVED IN A FUTURE UPDATE."
+  default     = false
+}
+
+variable "use_elastic_observer_ips" {
+  description = "Whether or not to give observers elastic IPs, maintaining one static IP forever. Disabled by default because clusters with more than 5 nodes in one region using elastic IPs will require personally requesting more EIPs from AWS."
   default     = false
 }
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -6,8 +6,8 @@ output "quorum_validator_node_dns" {
   value = "${module.quorum_cluster.quorum_validator_node_dns}"
 }
 
-output "quorum_observer_node_dns" {
-  value = "${module.quorum_cluster.quorum_observer_node_dns}"
+output "quorum_observer_node_ips" {
+  value = "${module.quorum_cluster.quorum_observer_node_ips}"
 }
 
 output "bootnode_ips" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -117,7 +117,12 @@ variable "use_dedicated_consul_servers" {
 }
 
 variable "use_elastic_bootnode_ips" {
-  description = "Whether or not to give bootnodes elastic IPs, maintaining one static IP forever. Disabled by default because clusters with more than 5 bootnodes in one region will require personally requesting more EIPs from AWS. WARNING: UNTESTED SINCE MOVING BOOTNODES INTO QUORUM VPC. MAY BE REMOVED IN A FUTURE UPDATE."
+  description = "Whether or not to give bootnodes elastic IPs, maintaining one static IP forever. Disabled by default because clusters with more than 5 nodes in one region using elastic IPs will require personally requesting more EIPs from AWS. WARNING: UNTESTED SINCE MOVING BOOTNODES INTO QUORUM VPC. MAY BE REMOVED IN A FUTURE UPDATE."
+  default     = false
+}
+
+variable "use_elastic_observer_ips" {
+  description = "Whether or not to give observers elastic IPs, maintaining one static IP forever. Disabled by default because clusters with more than 5 nodes in one region using elastic IPs will require personally requesting more EIPs from AWS."
   default     = false
 }
 


### PR DESCRIPTION
This should be a full implementation, but for some reason observers are failing with the following error in `/opt/quorum/log/quorum-error.log` when `using_elastic_observer_ips` is turned on:

`Fatal: Error starting protocol stack: listen tcp 18.235.214.56:22000: bind: cannot assign requested address`

They behave fine with it turned off, and the `init-quorum.sh` script fully succeeds with rebinding the address.  Still trying to figure out what the root issue could be here, [a comment on an issue with the same error](https://github.com/ethereum/go-ethereum/issues/15227#issuecomment-333786779) said:

> Probably something already listening, or not your actual address? Try `netstat -nlp`, and `ifconfig`. I'd guess you're on a private network, whereas 35.185.208.38 is a load balancer or firewall or something.

But I'm not really sure what they're getting at.